### PR TITLE
feat: Implement habit editing and deletion

### DIFF
--- a/lib/models/habit.dart
+++ b/lib/models/habit.dart
@@ -3,7 +3,7 @@ class Habit {
   final String theme;
   final int streak;
   final bool isCompleted;
-  
+
   Habit({
     required this.name,
     required this.theme,

--- a/lib/screens/edit_habit_screen.dart
+++ b/lib/screens/edit_habit_screen.dart
@@ -1,23 +1,41 @@
 import 'package:flutter/material.dart';
 import 'package:habit_tracker/models/habit.dart';
 
-class AddHabitScreen extends StatefulWidget {
-  const AddHabitScreen({super.key});
+class EditHabitScreen extends StatefulWidget {
+  final Habit habit;
+
+  const EditHabitScreen({super.key, required this.habit});
 
   @override
-  State<AddHabitScreen> createState() => _AddHabitScreenState();
+  State<EditHabitScreen> createState() => _EditHabitScreenState();
 }
 
-class _AddHabitScreenState extends State<AddHabitScreen> {
+class _EditHabitScreenState extends State<EditHabitScreen> {
   final _formKey = GlobalKey<FormState>();
-  String _habitName = '';
-  String _habitTheme = '';
+  late TextEditingController _nameController;
+  late TextEditingController _themeController;
+
+  @override
+  void initState() {
+    super.initState();
+    _nameController = TextEditingController(text: widget.habit.name);
+    _themeController = TextEditingController(text: widget.habit.theme);
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _themeController.dispose();
+    super.dispose();
+  }
 
   void _submit() {
     if (_formKey.currentState!.validate()) {
-      _formKey.currentState!.save();
-      final newHabit = Habit(name: _habitName, theme: _habitTheme);
-      Navigator.of(context).pop(newHabit);
+      final updatedHabit = widget.habit.copyWith(
+        name: _nameController.text,
+        theme: _themeController.text,
+      );
+      Navigator.of(context).pop(updatedHabit);
     }
   }
 
@@ -25,7 +43,7 @@ class _AddHabitScreenState extends State<AddHabitScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Add a New Habit'),
+        title: const Text('Edit Habit'),
       ),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
@@ -34,6 +52,7 @@ class _AddHabitScreenState extends State<AddHabitScreen> {
           child: Column(
             children: [
               TextFormField(
+                controller: _nameController,
                 decoration: const InputDecoration(labelText: 'Habit Name'),
                 validator: (value) {
                   if (value == null || value.isEmpty) {
@@ -41,11 +60,9 @@ class _AddHabitScreenState extends State<AddHabitScreen> {
                   }
                   return null;
                 },
-                onSaved: (value) {
-                  _habitName = value!;
-                },
               ),
               TextFormField(
+                controller: _themeController,
                 decoration: const InputDecoration(labelText: 'Theme'),
                 validator: (value) {
                   if (value == null || value.isEmpty) {
@@ -53,14 +70,11 @@ class _AddHabitScreenState extends State<AddHabitScreen> {
                   }
                   return null;
                 },
-                onSaved: (value) {
-                  _habitTheme = value!;
-                },
               ),
               const SizedBox(height: 20),
               ElevatedButton(
                 onPressed: _submit,
-                child: const Text('Add Habit'),
+                child: const Text('Save Changes'),
               ),
             ],
           ),

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:habit_tracker/models/habit.dart';
-
 import 'package:habit_tracker/screens/add_habit_screen.dart';
+import 'package:habit_tracker/screens/edit_habit_screen.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -11,7 +11,6 @@ class HomeScreen extends StatefulWidget {
 }
 
 class _HomeScreenState extends State<HomeScreen> {
-
   final List<Habit> _habits = [];
 
   void _addHabit() async {
@@ -45,7 +44,24 @@ class _HomeScreenState extends State<HomeScreen> {
     });
   }
 
+  void _deleteHabit(Habit habit) {
+    setState(() {
+      _habits.remove(habit);
+    });
+  }
 
+  void _editHabit(Habit habit) async {
+    final updatedHabit = await Navigator.of(context).push<Habit>(
+      MaterialPageRoute(builder: (context) => EditHabitScreen(habit: habit)),
+    );
+
+    if (updatedHabit != null) {
+      setState(() {
+        final habitIndex = _habits.indexOf(habit);
+        _habits[habitIndex] = updatedHabit;
+      });
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -54,30 +70,39 @@ class _HomeScreenState extends State<HomeScreen> {
         title: const Text('Habit Tracker'),
       ),
       body: ListView.builder(
-
         itemCount: _habits.length,
         itemBuilder: (context, index) {
           final habit = _habits[index];
-          return ListTile(
-            leading: CircleAvatar(
-              child: Text('${habit.streak}'),
+          return Dismissible(
+            key: ValueKey(habit),
+            onDismissed: (direction) {
+              _deleteHabit(habit);
+            },
+            background: Container(
+              color: Colors.red,
+              alignment: Alignment.centerRight,
+              padding: const EdgeInsets.only(right: 20.0),
+              child: const Icon(Icons.delete, color: Colors.white),
             ),
-            title: Text(habit.name),
-            subtitle: Text(habit.theme),
-            trailing: Checkbox(
-              value: habit.isCompleted,
-              onChanged: (value) {
-                _toggleHabitCompleted(habit);
-              },
+            child: ListTile(
+              onTap: () => _editHabit(habit),
+              leading: CircleAvatar(
+                child: Text('${habit.streak}'),
+              ),
+              title: Text(habit.name),
+              subtitle: Text(habit.theme),
+              trailing: Checkbox(
+                value: habit.isCompleted,
+                onChanged: (value) {
+                  _toggleHabitCompleted(habit);
+                },
+              ),
             ),
-
           );
         },
       ),
       floatingActionButton: FloatingActionButton(
-
         onPressed: _addHabit,
-
         child: const Icon(Icons.add),
       ),
     );

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -4,46 +4,75 @@ import 'package:habit_tracker/main.dart';
 
 void main() {
   testWidgets('Add and track a new habit', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
     await tester.pumpWidget(const MyApp());
-
-    // 1. Verify the initial state (no habits).
     expect(find.text('Learn Flutter'), findsNothing);
-    expect(find.text('Coding'), findsNothing);
 
-    // 2. Tap the '+' icon to navigate to the AddHabitScreen.
     await tester.tap(find.byIcon(Icons.add));
-    await tester.pumpAndSettle(); // Wait for the navigation to complete.
+    await tester.pumpAndSettle();
 
-    // 3. On AddHabitScreen, enter habit details.
     await tester.enterText(find.byType(TextFormField).at(0), 'Learn Flutter');
     await tester.enterText(find.byType(TextFormField).at(1), 'Coding');
-
-    // 4. Tap the 'Add Habit' button to submit.
     await tester.tap(find.text('Add Habit'));
-    await tester.pumpAndSettle(); // Wait for the navigation to complete.
+    await tester.pumpAndSettle();
 
-    // 5. Verify the new habit is displayed on the HomeScreen.
     expect(find.text('Learn Flutter'), findsOneWidget);
     expect(find.text('Coding'), findsOneWidget);
-
-    // 6. Verify the initial streak is '0'.
     expect(find.text('0'), findsOneWidget);
 
-    // 7. Tap the checkbox to complete the habit.
-    await tester.tap(find.byType(Checkbox));
-    await tester.pump(); // Re-render the widget.
-
-    // 8. Verify the streak is updated to '1'.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
-
-    // 9. Tap the checkbox again to un-complete the habit.
     await tester.tap(find.byType(Checkbox));
     await tester.pump();
 
-    // 10. Verify the streak is updated back to '0'.
+    expect(find.text('0'), findsNothing);
+    expect(find.text('1'), findsOneWidget);
+
+    await tester.tap(find.byType(Checkbox));
+    await tester.pump();
+
     expect(find.text('1'), findsNothing);
     expect(find.text('0'), findsOneWidget);
+  });
+
+  testWidgets('Edit an existing habit', (WidgetTester tester) async {
+    await tester.pumpWidget(const MyApp());
+
+    await tester.tap(find.byIcon(Icons.add));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextFormField).at(0), 'Initial Name');
+    await tester.enterText(find.byType(TextFormField).at(1), 'Initial Theme');
+    await tester.tap(find.text('Add Habit'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Initial Name'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Edit Habit'), findsOneWidget);
+
+    await tester.enterText(find.byType(TextFormField).at(0), 'Updated Name');
+    await tester.enterText(find.byType(TextFormField).at(1), 'Updated Theme');
+
+    await tester.tap(find.text('Save Changes'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Initial Name'), findsNothing);
+    expect(find.text('Updated Name'), findsOneWidget);
+    expect(find.text('Updated Theme'), findsOneWidget);
+  });
+
+  testWidgets('Delete a habit by swiping', (WidgetTester tester) async {
+    await tester.pumpWidget(const MyApp());
+
+    await tester.tap(find.byIcon(Icons.add));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextFormField).at(0), 'Habit to Delete');
+    await tester.enterText(find.byType(TextFormField).at(1), 'Some Theme');
+    await tester.tap(find.text('Add Habit'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Habit to Delete'), findsOneWidget);
+
+    await tester.drag(find.byType(Dismissible), const Offset(-500.0, 0.0));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Habit to Delete'), findsNothing);
   });
 }


### PR DESCRIPTION
This commit completes the local CRUD functionality for habits.

- Implements swipe-to-delete for habits on the home screen using the `Dismissible` widget.
- Adds an `EditHabitScreen` to allow users to modify the name and theme of existing habits.
- Updates the `HomeScreen` to handle navigation to the edit screen and process the updated habit data.
- Expands the widget test suite to cover the new edit and delete functionalities, ensuring the entire CRUD cycle is tested.